### PR TITLE
Fix l_2 regularization Prox

### DIFF
--- a/lightning/impl/svrg_fast.pyx
+++ b/lightning/impl/svrg_fast.pyx
@@ -147,7 +147,8 @@ def _svrg_fit(self,
             # A gradient is given by scale * X[i].
             scale = -loss.get_update(y_pred, y[i])
 
-            w_scale[0] *= (1 - eta_alpha)
+            # Apply the l_2 regularization proximal operator (not tested at all!)
+            w_scale[0] /= 1 + eta_alpha
 
             # Add deterministic part.
             #for j in xrange(n_features):


### PR DESCRIPTION
Yes, for small x,

   (1-x) \approx 1/(1+x)

but using the incorrect prox is, well, wrong, and also prevents convergence beyond 10-7 (which is a pity for an algorithm that CAN converge to numerical accuracy in reasonable time.

As mentioned in the comment, haven't tested the change in context, please have a long look at it! I had the same bug in my independent implementation(!), so I'm letting you know also.