### PR TITLE
FIX: compile on windows require to link against Advapi32.

### DIFF
--- a/lightning/impl/randomkit/setup.py
+++ b/lightning/impl/randomkit/setup.py
@@ -1,12 +1,18 @@
+import sys
 import numpy
 
 def configuration(parent_package='', top_path=None):
     from numpy.distutils.misc_util import Configuration
 
     config = Configuration('randomkit', parent_package, top_path)
+    libs = []
+    if sys.platform == 'win32':
+        libs.append('Advapi32')
+
 
     config.add_extension('random_fast',
          sources=['random_fast.cpp', 'randomkit.c'],
+         libraries=libs,
          include_dirs=[numpy.get_include()]
          )
 


### PR DESCRIPTION
I took this info from the numpy conterpart, and seems to work.
Tested on Windows 8.